### PR TITLE
Silent rendering

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,10 +29,10 @@ fn main() -> io::Result<()> {
     let out_file      = &args[4]; // relative path to output file
 
     // print arguments
-    println!("template path: {}", template_glob);
-    println!("template file: {}", template_file);
-    println!("json file: {}"    , json_file);
-    println!("out file: {}"     , out_file);
+    // println!("template path: {}", template_glob);
+    // println!("template file: {}", template_file);
+    // println!("json file: {}"    , json_file);
+    // println!("out file: {}"     , out_file);
 
     let mut file = File::open(json_file)?;
     let mut contents = String::new();
@@ -60,6 +60,6 @@ fn main() -> io::Result<()> {
         }
     };
 
-    println!("\n -> successfully rendered templates!");
+    // println!("-> successfully rendered template!\n");
     Ok(())
 }


### PR DESCRIPTION
I would like to deactivate the output of `t_renderer` for more compact output.
@zanellia any strong objections?
The binaries are generated automatically, when you do a tagged release on this repo, correct?